### PR TITLE
Updates CSS dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
     <style>
         @media (prefers-color-scheme: dark) {
             html {
-                background-color: #fff;
-                filter: hue-rotate(180deg) invert(100%);
-              }
-            .button.button-primary {
-                color: #222;
+                background-color: #222;
+            }
+            body,
+            .button {
+                color: #ddd;
             }
         }
     </style>


### PR DESCRIPTION
Re: #4 

Removes `filter: hue-rotate(180deg) invert();`
(which apparently has wonky browser implementation)

Instead changes page background color and body, `.button` color to match

Tested across Firefox, Safari, Chrome. Screenshot below shows browsers in the same order.

![image](https://user-images.githubusercontent.com/26461046/108395624-ff51d500-71e3-11eb-9138-12d59d767b70.png)
